### PR TITLE
Secondary claimants are more relaxed in the json schema - to allow fo…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    et_exporter (0.1.0)
+    et_exporter (0.1.1)
       jbuilder (~> 2.9, >= 2.9.1)
       pg
       rails (~> 5.2.3)

--- a/app/views/et_exporter/v1/_claimant.json.jbuilder
+++ b/app/views/et_exporter/v1/_claimant.json.jbuilder
@@ -3,4 +3,4 @@ json.(claimant, :gender, :mobile_number, :special_needs, :title)
 json.address do
   json.partial! "et_exporter/v1/address.json.jbuilder", address: claimant.address
 end
-json.contact_preference claimant.contact_preference.underscore
+json.contact_preference claimant.contact_preference&.underscore

--- a/lib/et_exporter/version.rb
+++ b/lib/et_exporter/version.rb
@@ -1,3 +1,3 @@
 module EtExporter
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/factories/claim_factory.rb
+++ b/spec/factories/claim_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
       number_of_claimants { 1 }
       number_of_respondents { 1 }
       has_representative { true }
+      secondary_claimant_traits { [:default] }
     end
     
     secondary_respondents { [] }
@@ -39,7 +40,7 @@ FactoryBot.define do
     after(:build) do |claim, evaluator|
       claim.primary_claimant = build(:claimant, :default) if claim.primary_claimant.blank? && evaluator.number_of_claimants > 0
       claim.primary_respondent = build(:respondent, :default) if claim.primary_respondent.blank? && evaluator.number_of_respondents > 0
-      claim.secondary_claimants.concat build_list(:claimant, [evaluator.number_of_claimants - 1, 0].max, :default)
+      claim.secondary_claimants.concat build_list(:claimant, [evaluator.number_of_claimants - 1, 0].max, *evaluator.secondary_claimant_traits)
       claim.secondary_respondents.concat build_list(:respondent, [evaluator.number_of_respondents - 1, 0].max, :default)
       claim.claimant_count += evaluator.number_of_claimants
       claim.primary_representative = build(:representative, :default) if claim.primary_representative.blank? && evaluator.has_representative

--- a/spec/factories/claimant_factory.rb
+++ b/spec/factories/claimant_factory.rb
@@ -1,20 +1,26 @@
 FactoryBot.define do
   factory :claimant do
     trait :default do
-      title { "Mr" }
-      first_name { "Paul" }
-      sequence(:last_name) { |idx| "O'Malley#{idx}" }
-      association :address,
-        building: '102',
-        street: 'Petty France',
-        locality: 'London',
-        county: 'Greater London',
-        post_code: 'SW1H 9AJ'
+      minimal
       address_telephone_number { '01234 567890' }
       mobile_number { '01234 098765' }
       email_address { 'test@digital.justice.gov.uk' }
       contact_preference { 'Email' }
       gender { 'Male' }
+      special_needs { 'My special needs are as follows' }
+      fax_number { '01234 123456' }
+    end
+
+    trait :minimal do
+      title { "Mr" }
+      first_name { "Paul" }
+      sequence(:last_name) { |idx| "O'Malley#{idx}" }
+      association :address,
+                  building: '102',
+                  street: 'Petty France',
+                  locality: 'London',
+                  county: 'Greater London',
+                  post_code: 'SW1H 9AJ'
       date_of_birth { Date.parse('21/11/1982') }
     end
   end

--- a/spec/support/json_schemas/exported_claim.json
+++ b/spec/support/json_schemas/exported_claim.json
@@ -54,7 +54,7 @@
         "send_claim_to_whistleblowing_entity": {"type": ["boolean", "null"]},
         "miscellaneous_information": {"type": ["string", "null"]},
         "is_unfair_dismissal": {"type": ["null", "boolean"]},
-        "secondary_claimants": {"type": "array", "items": {"$ref": "#/definitions/claimant"}},
+        "secondary_claimants": {"type": "array", "items": {"$ref": "#/definitions/secondary_claimant"}},
         "secondary_respondents": {"type": "array", "items": {"$ref": "#/definitions/respondent"}},
         "primary_claimant": {"$ref": "#/definitions/claimant"},
         "primary_respondent": {"$ref": "#/definitions/respondent"},
@@ -151,6 +151,25 @@
         "email_address": {"type": "string"},
         "contact_preference": {"type": "string", "enum": ["email", "post"]},
         "gender": {"type": "string", "enum": ["Male", "Female", "N/K"]},
+        "date_of_birth": {"$ref": "#/definitions/date"},
+        "fax_number": {"type": ["null", "string"]},
+        "special_needs": {"type": ["null", "string"]}
+      }
+    },
+    "secondary_claimant": {
+      "type": "object",
+      "required": ["title", "first_name", "last_name", "address"],
+      "additionalProperties": false,
+      "properties": {
+        "title": {"type": "string", "enum": ["Mr", "Mrs", "Miss", "Ms"]},
+        "first_name": {"type": "string"},
+        "last_name": {"type": "string"},
+        "address": {"$ref": "#/definitions/address"},
+        "address_telephone_number": {"type": ["string", "null"]},
+        "mobile_number": {"type": ["string", "null"]},
+        "email_address": {"type": ["string", "null"]},
+        "contact_preference": {"oneOf": [{"type": "string", "enum": ["email", "post"]}, {"type": "null"}]},
+        "gender": {"oneOf": [{"type": "string", "enum": ["Male", "Female", "N/K"]}, {"type": "null"}]},
         "date_of_birth": {"$ref": "#/definitions/date"},
         "fax_number": {"type": ["null", "string"]},
         "special_needs": {"type": ["null", "string"]}


### PR DESCRIPTION

Secondary claimants are more relaxed in the json schema - to allow for those imported from spreadsheet

Factories allow building of minimal claimants